### PR TITLE
feat: add block feed to virtual exchange

### DIFF
--- a/src/main/java/app/ai/lab/tradeEngineLite/BackTest/Exchange/OrderManagementService.java
+++ b/src/main/java/app/ai/lab/tradeEngineLite/BackTest/Exchange/OrderManagementService.java
@@ -1,5 +1,6 @@
 package app.ai.lab.tradeEngineLite.BackTest.Exchange;
 
+import app.ai.lab.tradeEngineLite.BackTest.Engine.HistoricalData.Block;
 import org.springframework.stereotype.Service;
 
 import java.util.function.BiConsumer;
@@ -67,5 +68,10 @@ public class OrderManagementService {
     /** Forward price feed data to the underlying exchange. */
     public void instrumentPriceFeed(int instrumentId, double priceLtp, double priceAsk, double priceBid) {
         exchange.instrumentPriceFeed(instrumentId, priceLtp, priceAsk, priceBid);
+    }
+
+    /** Forward a historical data block to the exchange. */
+    public void onBlock(Block block) {
+        exchange.onBlock(block);
     }
 }

--- a/src/test/java/app/ai/lab/tradeEngineLite/BackTest/Exchange/VirtualExchangeTest.java
+++ b/src/test/java/app/ai/lab/tradeEngineLite/BackTest/Exchange/VirtualExchangeTest.java
@@ -1,0 +1,47 @@
+package app.ai.lab.tradeEngineLite.BackTest.Exchange;
+
+import app.ai.lab.tradeEngineLite.BackTest.Engine.HistoricalData.Block;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class VirtualExchangeTest {
+
+    static class TestVirtualExchange extends VirtualExchange {
+        final List<Integer> processedTokens = new ArrayList<>();
+        @Override
+        public void instrumentPriceFeed(int instrumentId, double priceLtp, double priceAsk, double priceBid) {
+            processedTokens.add(instrumentId);
+            super.instrumentPriceFeed(instrumentId, priceLtp, priceAsk, priceBid);
+        }
+    }
+
+    @Test
+    void onBlockProcessesOnlyActiveInstruments() {
+        TestVirtualExchange exchange = new TestVirtualExchange();
+        exchange.placeOrder(new VirtualExchange.Order(1, VirtualExchange.OrderType.BUY_M, 0.0, 0.0));
+
+        Block block = new Block();
+        block.setTimeStamp(0L);
+        List<Block.PacketData> packets = new ArrayList<>();
+
+        Block.IndexPacket p1 = new Block.IndexPacket();
+        p1.setToken(1);
+        p1.setLastTradedPrice(10000); // 100.00
+        packets.add(p1);
+
+        Block.IndexPacket p2 = new Block.IndexPacket();
+        p2.setToken(2);
+        p2.setLastTradedPrice(20000); // 200.00
+        packets.add(p2);
+
+        block.setInfo(packets);
+
+        exchange.onBlock(block);
+
+        assertEquals(List.of(1), exchange.processedTokens);
+    }
+}


### PR DESCRIPTION
## Summary
- allow VirtualExchange to consume historical Block data
- expose onBlock in OrderManagementService
- filter block processing to active instruments

## Testing
- `sh gradlew test` *(fails: Could not determine the dependencies of task ':test'. Could not resolve all dependencies for configuration ':testRuntimeClasspath'. Failed to calculate the value of task ':compileTestJava' property 'javaCompiler'. Cannot find a Java installation on your machine (Linux 6.12.13 amd64) matching: {languageVersion=17, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. Toolchain download repositories have not been configured.)*

------
https://chatgpt.com/codex/tasks/task_e_68c54b820aa4832e8027c4f0f7b40095